### PR TITLE
modification

### DIFF
--- a/progeny_root/core/heritage_versioning.py
+++ b/progeny_root/core/heritage_versioning.py
@@ -9,6 +9,7 @@ Manages version history for heritage files:
 import json
 import logging
 import shutil
+import time
 from pathlib import Path
 from typing import Dict, Any, Optional
 from datetime import datetime
@@ -160,7 +161,7 @@ class HeritageVersioning:
             
             current_version = data.get("version", 1)
             data["version"] = current_version + 1
-            data["last_modified_ts"] = datetime.now().isoformat()
+            data["last_modified_ts"] = int(time.time())
             
             with open(file_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)


### PR DESCRIPTION
This pull request makes a minor update to the `increment_version` method in `heritage_versioning.py` to modify how the `last_modified_ts` field is set.

- The method now sets `last_modified_ts` to the current time as an integer (Unix timestamp), but the next line immediately overwrites it with the floating-point value from `time.time()`. This likely introduces redundancy or a potential bug, as the integer assignment has no effect.